### PR TITLE
Fix pg_stat_statements query for PG17 column renames

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -36,6 +36,7 @@ jobs:
           config_file=$(psql --no-psqlrc -U postgres -Atqc 'SHOW config_file')
           echo "shared_preload_libraries = 'pg_stat_statements,pgsentinel'" >> "$config_file"
           echo "pgsentinel.db_name = 'contrib_regression'" >> "$config_file"
+          echo "pgsentinel_pgssh.enable = true" >> "$config_file"
           pg_ctlcluster ${{ matrix.pg }} test restart
 
       - name: Run regression tests

--- a/src/expected/pgsentinel-test.out
+++ b/src/expected/pgsentinel-test.out
@@ -12,6 +12,18 @@ select count(*) > 0 AS has_data from pg_active_session_history where queryid in 
  t
 (1 row)
 
+select pg_sleep(3);
+ pg_sleep 
+----------
+ 
+(1 row)
+
+select count(*) > 0 AS has_pgssh_data from pg_stat_statements_history;
+ has_pgssh_data 
+----------------
+ t
+(1 row)
+
 begin;
 \! sleep 3
 commit;

--- a/src/pgsentinel.c
+++ b/src/pgsentinel.c
@@ -204,11 +204,25 @@ static const char * const pg_stat_statements_query=
  where queryid in  (select queryid from pg_active_session_history  \
  where ash_time in (select ash_time from pg_active_session_history  \
  order by ash_time desc limit 1))";
-#else
+#elif PG_VERSION_NUM < 170000
 "select userid, dbid, queryid, calls, total_exec_time, rows, shared_blks_hit, \
  shared_blks_read, shared_blks_dirtied, shared_blks_written, local_blks_hit, \
  local_blks_read, local_blks_dirtied, local_blks_written, temp_blks_read, \
  temp_blks_written, blk_read_time, blk_write_time, \
+ plans, total_plan_time, wal_records, wal_fpi, wal_bytes \
+ from pg_stat_statements \
+ where queryid in  (select queryid from pg_active_session_history  \
+ where ash_time in (select ash_time from pg_active_session_history  \
+ order by ash_time desc limit 1))";
+#else
+/* PG17: pg_stat_statements 1.11 renamed the following columns:
+ *       blk_read_time -> shared_blk_read_time,
+ *       blk_write_time -> shared_blk_write_time
+ */
+"select userid, dbid, queryid, calls, total_exec_time, rows, shared_blks_hit, \
+ shared_blks_read, shared_blks_dirtied, shared_blks_written, local_blks_hit, \
+ local_blks_read, local_blks_dirtied, local_blks_written, temp_blks_read, \
+ temp_blks_written, shared_blk_read_time, shared_blk_write_time, \
  plans, total_plan_time, wal_records, wal_fpi, wal_bytes \
  from pg_stat_statements \
  where queryid in  (select queryid from pg_active_session_history  \

--- a/src/pgsentinel.conf
+++ b/src/pgsentinel.conf
@@ -1,2 +1,3 @@
 shared_preload_libraries = 'pg_stat_statements,pgsentinel'
 pgsentinel.db_name = 'contrib_regression'
+pgsentinel_pgssh.enable = true

--- a/src/sql/pgsentinel-test.sql
+++ b/src/sql/pgsentinel-test.sql
@@ -2,6 +2,8 @@ CREATE EXTENSION pg_stat_statements;
 CREATE EXTENSION pgsentinel;
 select pg_sleep(3);
 select count(*) > 0 AS has_data from pg_active_session_history where queryid in (select queryid from pg_stat_statements);
+select pg_sleep(3);
+select count(*) > 0 AS has_pgssh_data from pg_stat_statements_history;
 
 begin;
 \! sleep 3


### PR DESCRIPTION
  PG17's pg_stat_statements (v1.11) renamed:
     blk_read_time -> shared_blk_read_time
     blk_write_time -> shared_blk_write_time.
  Add a PG_VERSION_NUM >= 170000 query variant so the pgssh feature
  works on PG17.