### PR TITLE
Fix builds against PostgreSQL 19

### DIFF
--- a/src/get_parsedinfo.c
+++ b/src/get_parsedinfo.c
@@ -25,6 +25,7 @@
 #include "pgstat.h"
 #include "postmaster/autovacuum.h"
 #include "replication/walsender.h"
+#include "utils/tuplestore.h"
 
 Datum get_parsedinfo(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(get_parsedinfo);
@@ -87,8 +88,10 @@ get_max_procs_count(void)
 void
 #if PG_VERSION_NUM < 140000
 getparsedinfo_post_parse_analyze(ParseState *pstate, Query *query)
-#else
+#elif PG_VERSION_NUM < 190000
 getparsedinfo_post_parse_analyze(ParseState *pstate, Query *query, JumbleState *jstate)
+#else
+getparsedinfo_post_parse_analyze(ParseState *pstate, Query *query, const JumbleState *jstate)
 #endif
 {
 

--- a/src/pgsentinel.c
+++ b/src/pgsentinel.c
@@ -29,6 +29,7 @@
 #include "utils/date.h"
 #include "utils/builtins.h"
 #include "utils/memutils.h"
+#include "utils/tuplestore.h"
 #include "funcapi.h"
 #include "optimizer/planner.h"
 #include "storage/shm_toc.h"
@@ -794,6 +795,18 @@ pgsentinel_sighup(SIGNAL_ARGS)
 	errno = save_errno;
 }
 
+/*
+ * On PG19, pqsignal()'s handler type (pqsigfunc) gained an extra
+ * "const pg_signal_info *" argument, which the SIG_IGN macro is not
+ * typed to accept. Use an explicit no-op handler instead of SIG_IGN
+ * so the function pointer types match on all supported versions.
+ */
+static void
+pgsentinel_sigint(SIGNAL_ARGS)
+{
+	/* Ignore SIGINT. */
+}
+
 static void
 ash_entry_store(TimestampTz ash_time, const int pid,
 #if PG_VERSION_NUM >= 130000
@@ -903,7 +916,7 @@ pgsentinel_main(Datum main_arg)
 
 	/* Register functions for SIGTERM/SIGHUP management */
 	pqsignal(SIGHUP, pgsentinel_sighup);
-	pqsignal(SIGINT, SIG_IGN);
+	pqsignal(SIGINT, pgsentinel_sigint);
 	pqsignal(SIGTERM, pgsentinel_sigterm);
 
 	/* We're now ready to receive signals */

--- a/src/pgsentinel.h
+++ b/src/pgsentinel.h
@@ -15,8 +15,10 @@ extern post_parse_analyze_hook_type prev_post_parse_analyze_hook;
 /* Our hooks */
 #if PG_VERSION_NUM < 140000
 extern void getparsedinfo_post_parse_analyze(ParseState *pstate, Query *query);
-#else
+#elif PG_VERSION_NUM < 190000
 extern void getparsedinfo_post_parse_analyze(ParseState *pstate, Query *query, JumbleState *jstate);
+#else
+extern void getparsedinfo_post_parse_analyze(ParseState *pstate, Query *query, const JumbleState *jstate);
 #endif
 /* Estimate amount of shared memory needed */
 extern Size proc_entry_memsize(void);


### PR DESCRIPTION
 1. pgsentinel.c / pgsentinel.h / get_parsedinfo.c
   - post_parse_analyze_hook_type's `jstate` parameter is now `const JumbleState *` on PG19 (was a plain `JumbleState *`). Added a new `PG_VERSION_NUM < 190000` branch to the existing version-gated prototype/definition so the hook signature matches exactly on PG19, while leaving all older branches untouched. Fixes: "assigning to 'post_parse_analyze_hook_type' ... from incompatible pointer type" (pgsentinel.c:1423)

2. get_parsedinfo.c / pgsentinel.c
   - `tuplestore_begin_heap()` / `tuplestore_putvalues()` are no longer transitively visible via funcapi.h on PG19; utils/tuplestore.h must now be included directly. Added the missing #include to both translation units. Fixes: "call to undeclared function 'tuplestore_begin_heap'" "call to undeclared function 'tuplestore_putvalues'"

3. pgsentinel.c
   - pqsignal()'s handler type (pqsigfunc) gained an extra `const pg_signal_info *` parameter on PG19, so the classic `SIG_IGN` macro (typed as `void (*)(int)`) no longer matches and can't be passed to pqsignal(SIGINT, ...). Added a small no-op signal handler (`pgsentinel_sigint`) with the correct SIGNAL_ARGS signature and pass that instead of SIG_IGN. Fixes: "incompatible function pointer types passing '__sighandler_t' ... to parameter of type 'pqsigfunc'" (pgsentinel.c:896)

Coded by Claude, tested by me.

Per : https://github.com/pgdg-packaging/pgdg-rpms/issues/213