### PR TITLE
pgssh: capture sample after query completion and dont read query text file

### DIFF
--- a/src/expected/pgsentinel-test.out
+++ b/src/expected/pgsentinel-test.out
@@ -24,6 +24,56 @@ select count(*) > 0 AS has_pgssh_data from pg_stat_statements_history;
  t
 (1 row)
 
+select 'test2' test2, pg_sleep(3);
+ test2 | pg_sleep 
+-------+----------
+ test2 | 
+(1 row)
+
+select 'test2' test2, pg_sleep(3);
+ test2 | pg_sleep 
+-------+----------
+ test2 | 
+(1 row)
+
+-- Elicit a few seconds where pgsentinel collection is idle.
+\! sleep 2
+-- Exercise pgssh's limit 2 path when the query disappears from ASH while collection is not idle.
+with ash as (
+	select queryid, max(ash_time) as max_ash_time
+	from pg_active_session_history
+	where query like 'select pg_sleep(3)%'
+	group by queryid
+), pgssh as (
+	select queryid, max(ash_time) as max_ash_time
+	from pg_stat_statements_history
+	group by queryid
+)
+select pgssh.max_ash_time > ash.max_ash_time as pgssh_after_ash
+from ash join pgssh using (queryid);
+ pgssh_after_ash 
+-----------------
+ t
+(1 row)
+
+-- Exercise pgssh's collect_pgssh_on_idle path when the query disappears from ASH while collection is idle.
+with ash as (
+	select queryid, max(ash_time) as max_ash_time
+	from pg_active_session_history
+	where query like 'select ''test2'' test2, pg_sleep(3)%'
+	group by queryid
+), pgssh as (
+	select queryid, max(ash_time) as max_ash_time
+	from pg_stat_statements_history
+	group by queryid
+)
+select pgssh.max_ash_time > ash.max_ash_time as pgssh_after_ash
+from ash join pgssh using (queryid);
+ pgssh_after_ash 
+-----------------
+ t
+(1 row)
+
 begin;
 \! sleep 3
 commit;

--- a/src/pgsentinel.c
+++ b/src/pgsentinel.c
@@ -201,7 +201,7 @@ static const char * const pg_stat_statements_query=
 "select userid, dbid, queryid, calls, total_time, rows, shared_blks_hit, \
  shared_blks_read, shared_blks_dirtied, shared_blks_written, local_blks_hit, \
  local_blks_read, local_blks_dirtied, local_blks_written, temp_blks_read, \
- temp_blks_written, blk_read_time, blk_write_time from pg_stat_statements \
+ temp_blks_written, blk_read_time, blk_write_time from pg_stat_statements(false) \
  where queryid in  (select queryid from pg_active_session_history  \
  where ash_time in (select ash_time from pg_active_session_history  \
  order by ash_time desc limit 2))";
@@ -211,7 +211,7 @@ static const char * const pg_stat_statements_query=
  local_blks_read, local_blks_dirtied, local_blks_written, temp_blks_read, \
  temp_blks_written, blk_read_time, blk_write_time, \
  plans, total_plan_time, wal_records, wal_fpi, wal_bytes \
- from pg_stat_statements \
+ from pg_stat_statements(false) \
  where queryid in  (select queryid from pg_active_session_history  \
  where ash_time in (select ash_time from pg_active_session_history  \
  order by ash_time desc limit 2))";
@@ -221,7 +221,7 @@ static const char * const pg_stat_statements_query=
  local_blks_read, local_blks_dirtied, local_blks_written, temp_blks_read, \
  temp_blks_written, shared_blk_read_time, shared_blk_write_time, \
  plans, total_plan_time, wal_records, wal_fpi, wal_bytes \
- from pg_stat_statements \
+ from pg_stat_statements(false) \
  where queryid in  (select queryid from pg_active_session_history  \
  where ash_time in (select ash_time from pg_active_session_history  \
  order by ash_time desc limit 2))";

--- a/src/pgsentinel.c
+++ b/src/pgsentinel.c
@@ -204,7 +204,7 @@ static const char * const pg_stat_statements_query=
  temp_blks_written, blk_read_time, blk_write_time from pg_stat_statements \
  where queryid in  (select queryid from pg_active_session_history  \
  where ash_time in (select ash_time from pg_active_session_history  \
- order by ash_time desc limit 1))";
+ order by ash_time desc limit 2))";
 #elif PG_VERSION_NUM < 170000
 "select userid, dbid, queryid, calls, total_exec_time, rows, shared_blks_hit, \
  shared_blks_read, shared_blks_dirtied, shared_blks_written, local_blks_hit, \
@@ -214,7 +214,7 @@ static const char * const pg_stat_statements_query=
  from pg_stat_statements \
  where queryid in  (select queryid from pg_active_session_history  \
  where ash_time in (select ash_time from pg_active_session_history  \
- order by ash_time desc limit 1))";
+ order by ash_time desc limit 2))";
 #else
 "select userid, dbid, queryid, calls, total_exec_time, rows, shared_blks_hit, \
  shared_blks_read, shared_blks_dirtied, shared_blks_written, local_blks_hit, \
@@ -224,7 +224,7 @@ static const char * const pg_stat_statements_query=
  from pg_stat_statements \
  where queryid in  (select queryid from pg_active_session_history  \
  where ash_time in (select ash_time from pg_active_session_history  \
- order by ash_time desc limit 1))";
+ order by ash_time desc limit 2))";
 #endif
 
 static void pg_active_session_history_internal(FunctionCallInfo fcinfo);
@@ -899,6 +899,7 @@ pgsentinel_main(Datum main_arg)
 {
 	MemoryContext pgsentinel_loop_context;
 	MemoryContext saved_context;
+	bool collect_pgssh_on_idle = false;
 
 	ereport(LOG, (errmsg("starting bgworker pgsentinel")));
 
@@ -932,6 +933,7 @@ pgsentinel_main(Datum main_arg)
 		int rc, ret;
 		uint64 i;
 		bool gotactives;
+		bool collect_pgssh;
 		TimestampTz ash_time;
 		gotactives=false; 
 
@@ -1259,7 +1261,11 @@ letswait:
 		pgstat_report_activity(STATE_IDLE, NULL);
 
 		/* pg_stat_statement_history */
-		if (gotactives && pgssh_enable) 
+		collect_pgssh = gotactives || collect_pgssh_on_idle;
+		/* Remember active sessions so pg_stat_statement_history is collected once on the following idle cycle. */
+		collect_pgssh_on_idle = gotactives;
+
+		if (collect_pgssh && pgssh_enable) 
 		{
 			SetCurrentStatementStartTimestamp();
 			StartTransactionCommand();

--- a/src/sql/pgsentinel-test.sql
+++ b/src/sql/pgsentinel-test.sql
@@ -4,6 +4,38 @@ select pg_sleep(3);
 select count(*) > 0 AS has_data from pg_active_session_history where queryid in (select queryid from pg_stat_statements);
 select pg_sleep(3);
 select count(*) > 0 AS has_pgssh_data from pg_stat_statements_history;
+select 'test2' test2, pg_sleep(3);
+select 'test2' test2, pg_sleep(3);
+-- Elicit a few seconds where pgsentinel collection is idle.
+\! sleep 2
+
+-- Exercise pgssh's limit 2 path when the query disappears from ASH while collection is not idle.
+with ash as (
+	select queryid, max(ash_time) as max_ash_time
+	from pg_active_session_history
+	where query like 'select pg_sleep(3)%'
+	group by queryid
+), pgssh as (
+	select queryid, max(ash_time) as max_ash_time
+	from pg_stat_statements_history
+	group by queryid
+)
+select pgssh.max_ash_time > ash.max_ash_time as pgssh_after_ash
+from ash join pgssh using (queryid);
+
+-- Exercise pgssh's collect_pgssh_on_idle path when the query disappears from ASH while collection is idle.
+with ash as (
+	select queryid, max(ash_time) as max_ash_time
+	from pg_active_session_history
+	where query like 'select ''test2'' test2, pg_sleep(3)%'
+	group by queryid
+), pgssh as (
+	select queryid, max(ash_time) as max_ash_time
+	from pg_stat_statements_history
+	group by queryid
+)
+select pgssh.max_ash_time > ash.max_ash_time as pgssh_after_ash
+from ash join pgssh using (queryid);
 
 begin;
 \! sleep 3


### PR DESCRIPTION
use `limit 2` and a boolean variable to ensure we capture one additional pgssh sample for every query after the query no longer appears in the ASH. also set `showtext=false` on pgss queries to avoid unnecessarily reading the query text file.

Fixes #67 