### PR TITLE
add nested queryid and bump version to 1.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Usage
   | query            | text                     |           |          |  |
   | cmdtype          | text                     |           |          |  |
   | queryid          | bigint                   |           |          |  |
+  | nested_queryid   | bigint                   |           |          |  |
   | backend_type     | text                     |           |          |  |
   | blockers         | integer                  |           |          |  |
   | blockerpid       | integer                  |           |          |  |
@@ -112,13 +113,16 @@ Usage
 You can see it as samplings of `pg_stat_activity` providing more information:
 
 * `ash_time`: the sampling time
-* `top_level_query`: the top level statement (in case PL/pgSQL is used)
-* `query`: the statement being executed (not normalised, as it is in `pg_stat_statements`, which means you see parameter values)
+* `top_level_query`: the top-level statement from `pg_stat_activity.query` (in case PL/pgSQL is used)
+* `query`: the statement currently being executed, from `get_parsedinfo()` (not normalised, so parameter values are visible)
 * `cmdtype`: the statement type (SELECT,UPDATE,INSERT,DELETE,UTILITY,UNKNOWN,NOTHING)
-* `queryid`: the queryid of the statement which links to pg_stat_statements
+* `queryid`: the top-level query ID from `pg_stat_activity.query_id`[^1], which links to `pg_stat_statements`
+* `nested_queryid`: the query ID returned by `get_parsedinfo()` for the statement currently being executed
 * `blockers`: the number of blockers
 * `blockerpid`: the pid of the blocker (if blockers = 1), the pid of one blocker (if blockers > 1)
 * `blocker_state`: state of the blocker (state of the blockerpid) 
+
+[^1]: Before PostgreSQL 16, `queryid` also comes from `get_parsedinfo()` and therefore matches `nested_queryid`.
 
 `pgsentinel` also reports query statistics history through the `pg_stat_statements_history` view:
 

--- a/src/expected/pgsentinel-test.out
+++ b/src/expected/pgsentinel-test.out
@@ -24,6 +24,56 @@ select count(*) > 0 AS has_pgssh_data from pg_stat_statements_history;
  t
 (1 row)
 
+select 'test2' test2, pg_sleep(3);
+ test2 | pg_sleep 
+-------+----------
+ test2 | 
+(1 row)
+
+select 'test2' test2, pg_sleep(3);
+ test2 | pg_sleep 
+-------+----------
+ test2 | 
+(1 row)
+
+-- Elicit a few seconds where pgsentinel collection is idle.
+\! sleep 2
+-- Exercise pgssh's limit 2 path when the query disappears from ASH while collection is not idle.
+with ash as (
+	select queryid, max(ash_time) as max_ash_time
+	from pg_active_session_history
+	where query like 'select pg_sleep(3)%'
+	group by queryid
+), pgssh as (
+	select queryid, max(ash_time) as max_ash_time
+	from pg_stat_statements_history
+	group by queryid
+)
+select pgssh.max_ash_time > ash.max_ash_time as pgssh_after_ash
+from ash join pgssh using (queryid);
+ pgssh_after_ash 
+-----------------
+ t
+(1 row)
+
+-- Exercise pgssh's collect_pgssh_on_idle path when the query disappears from ASH while collection is idle.
+with ash as (
+	select queryid, max(ash_time) as max_ash_time
+	from pg_active_session_history
+	where query like 'select ''test2'' test2, pg_sleep(3)%'
+	group by queryid
+), pgssh as (
+	select queryid, max(ash_time) as max_ash_time
+	from pg_stat_statements_history
+	group by queryid
+)
+select pgssh.max_ash_time > ash.max_ash_time as pgssh_after_ash
+from ash join pgssh using (queryid);
+ pgssh_after_ash 
+-----------------
+ t
+(1 row)
+
 begin;
 \! sleep 3
 commit;

--- a/src/expected/pgsentinel-test.out
+++ b/src/expected/pgsentinel-test.out
@@ -1,5 +1,6 @@
 CREATE EXTENSION pg_stat_statements;
 CREATE EXTENSION pgsentinel;
+SET pg_stat_statements.track = 'all';
 select pg_sleep(3);
  pg_sleep 
 ----------
@@ -12,6 +13,53 @@ select count(*) > 0 AS has_data from pg_active_session_history where queryid in 
  t
 (1 row)
 
+CREATE FUNCTION pgsentinel_nested_queryid_test() RETURNS void AS $$
+BEGIN
+  PERFORM pg_sleep(4);
+END;
+$$ LANGUAGE plpgsql;
+SELECT pgsentinel_nested_queryid_test();
+ pgsentinel_nested_queryid_test 
+--------------------------------
+ 
+(1 row)
+
+-- Verify ASH records a distinct nested query ID.
+SELECT CASE WHEN current_setting('server_version_num')::integer >= 160000
+       THEN count(*) > 0 ELSE true END AS has_nested_queryid
+FROM pg_active_session_history
+WHERE nested_queryid IS NOT NULL AND nested_queryid <> queryid;
+ has_nested_queryid 
+--------------------
+ t
+(1 row)
+
+SELECT pgsentinel_nested_queryid_test();
+ pgsentinel_nested_queryid_test 
+--------------------------------
+ 
+(1 row)
+
+-- Verify pgssh includes both top-level and nested query IDs.
+SELECT CASE WHEN current_setting('server_version_num')::integer >= 160000
+       THEN count(DISTINCT h.queryid) = 2 ELSE true END
+       AS has_nested_pgssh_queryids
+FROM pg_stat_statements_history AS h
+WHERE h.queryid IN (
+  SELECT queryid
+  FROM pg_active_session_history
+  WHERE top_level_query LIKE 'SELECT pgsentinel_nested_queryid_test()%'
+  UNION
+  SELECT nested_queryid
+  FROM pg_active_session_history
+  WHERE top_level_query LIKE 'SELECT pgsentinel_nested_queryid_test()%'
+);
+ has_nested_pgssh_queryids 
+---------------------------
+ t
+(1 row)
+
+DROP FUNCTION pgsentinel_nested_queryid_test();
 select pg_sleep(3);
  pg_sleep 
 ----------

--- a/src/pgsentinel--1.4.1--1.5.0.sql
+++ b/src/pgsentinel--1.4.1--1.5.0.sql
@@ -1,0 +1,27 @@
+/* pgsentinel--1.4.1--1.5.0.sql */
+
+\echo Use "ALTER EXTENSION pgsentinel UPDATE TO '1.5.0'" to load this file. \quit
+
+DROP VIEW pg_active_session_history;
+DROP FUNCTION pg_active_session_history();
+
+CREATE FUNCTION pg_active_session_history(
+    OUT ash_time timestamptz, OUT datid Oid, OUT datname text,
+    OUT pid integer, OUT leader_pid integer, OUT usesysid Oid,
+    OUT usename text, OUT application_name text, OUT client_addr text,
+    OUT client_hostname text, OUT client_port integer,
+    OUT backend_start timestamptz, OUT xact_start timestamptz,
+    OUT query_start timestamptz, OUT state_change timestamptz,
+    OUT wait_event_type text, OUT wait_event text, OUT state text,
+    OUT backend_xid xid, OUT backend_xmin xid, OUT top_level_query text,
+    OUT query text, OUT cmdtype text, OUT queryid bigint,
+    OUT nested_queryid bigint, OUT backend_type text, OUT blockers integer,
+    OUT blockerpid integer, OUT blocker_state text)
+RETURNS SETOF record
+AS 'MODULE_PATHNAME', 'pg_active_session_history'
+LANGUAGE C STRICT VOLATILE PARALLEL SAFE;
+
+CREATE VIEW pg_active_session_history AS
+  SELECT * FROM pg_active_session_history();
+
+GRANT SELECT ON pg_active_session_history TO PUBLIC;

--- a/src/pgsentinel.c
+++ b/src/pgsentinel.c
@@ -55,7 +55,7 @@ PG_MODULE_MAGIC;
 PG_FUNCTION_INFO_V1(pg_active_session_history);
 PG_FUNCTION_INFO_V1(pg_stat_statements_history);
 
-#define PG_ACTIVE_SESSION_HISTORY_COLS        28
+#define PG_ACTIVE_SESSION_HISTORY_COLS        29
 #define PG_STAT_STATEMENTS_HISTORY_COLS       24
 #define EXTENSION_NAME "pgsentinel"
 
@@ -101,7 +101,8 @@ static const char * const pgsa_query_no_track_idle=
  else act.wait_event_type end as wait_event_type,case when act.wait_event is null \
  then 'CPU' else act.wait_event end as wait_event, act.state, act.backend_xid, \
  act.backend_xmin, act.query,(pg_blocking_pids(act.pid))[1], \
- cardinality(pg_blocking_pids(act.pid)),blk.state,gpi.* \
+ cardinality(pg_blocking_pids(act.pid)),blk.state,gpi.pid,gpi.queryid, \
+ gpi.queryid,gpi.query,gpi.cmdtype \
  from pg_stat_activity act left join pg_stat_activity blk  \
  on (pg_blocking_pids(act.pid))[1] = blk.pid,get_parsedinfo(act.pid) gpi \
  where act.state ='active' and act.pid != pg_backend_pid()";
@@ -113,7 +114,8 @@ static const char * const pgsa_query_no_track_idle=
  else act.wait_event_type end as wait_event_type,case when act.wait_event is null \
  then 'CPU' else act.wait_event end as wait_event, act.state, act.backend_xid, \
  act.backend_xmin, act.query, act.backend_type,(pg_blocking_pids(act.pid))[1], \
- cardinality(pg_blocking_pids(act.pid)),blk.state,gpi.* \
+ cardinality(pg_blocking_pids(act.pid)),blk.state,gpi.pid,gpi.queryid, \
+ gpi.queryid,gpi.query,gpi.cmdtype \
  from pg_stat_activity act left join pg_stat_activity blk  \
  on (pg_blocking_pids(act.pid))[1] = blk.pid,get_parsedinfo(act.pid) gpi \
  where act.state ='active' and act.pid != pg_backend_pid()";
@@ -125,7 +127,8 @@ static const char * const pgsa_query_no_track_idle=
  else act.wait_event_type end as wait_event_type,case when act.wait_event is null \
  then 'CPU' else act.wait_event end as wait_event, act.state, act.backend_xid, \
  act.backend_xmin, act.query, act.backend_type,(pg_blocking_pids(act.pid))[1], \
- cardinality(pg_blocking_pids(act.pid)),blk.state,gpi.*, act.leader_pid \
+ cardinality(pg_blocking_pids(act.pid)),blk.state,gpi.pid,gpi.queryid, \
+ gpi.queryid,gpi.query,gpi.cmdtype,act.leader_pid \
  from pg_stat_activity act left join pg_stat_activity blk  \
  on (pg_blocking_pids(act.pid))[1] = blk.pid,get_parsedinfo(act.pid) gpi \
  where act.state ='active' and act.pid != pg_backend_pid()";
@@ -137,7 +140,7 @@ static const char * const pgsa_query_no_track_idle=
  else act.wait_event_type end as wait_event_type,case when act.wait_event is null \
  then 'CPU' else act.wait_event end as wait_event, act.state, act.backend_xid, \
  act.backend_xmin, act.query, act.backend_type,(pg_blocking_pids(act.pid))[1], \
- cardinality(pg_blocking_pids(act.pid)),blk.state,gpi.pid,act.query_id, \
+ cardinality(pg_blocking_pids(act.pid)),blk.state,gpi.pid,gpi.queryid,act.query_id, \
  gpi.query, gpi.cmdtype, act.leader_pid \
  from pg_stat_activity act left join pg_stat_activity blk  \
  on (pg_blocking_pids(act.pid))[1] = blk.pid,get_parsedinfo(act.pid) gpi \
@@ -153,7 +156,8 @@ static const char * const pgsa_query_track_idle=
  else act.wait_event_type end as wait_event_type,case when act.wait_event is null \
  then 'CPU' else act.wait_event end as wait_event, act.state, act.backend_xid, \
  act.backend_xmin, act.query,(pg_blocking_pids(act.pid))[1], \
- cardinality(pg_blocking_pids(act.pid)),blk.state,gpi.* \
+ cardinality(pg_blocking_pids(act.pid)),blk.state,gpi.pid,gpi.queryid, \
+ gpi.queryid,gpi.query,gpi.cmdtype \
  from pg_stat_activity act left join pg_stat_activity blk  \
  on (pg_blocking_pids(act.pid))[1] = blk.pid,get_parsedinfo(act.pid) gpi \
  where act.state in ('active', 'idle in transaction') and act.pid != pg_backend_pid()";
@@ -165,7 +169,8 @@ static const char * const pgsa_query_track_idle=
  else act.wait_event_type end as wait_event_type,case when act.wait_event is null \
  then 'CPU' else act.wait_event end as wait_event, act.state, act.backend_xid, \
  act.backend_xmin, act.query, act.backend_type,(pg_blocking_pids(act.pid))[1], \
- cardinality(pg_blocking_pids(act.pid)),blk.state,gpi.* \
+ cardinality(pg_blocking_pids(act.pid)),blk.state,gpi.pid,gpi.queryid, \
+ gpi.queryid,gpi.query,gpi.cmdtype \
  from pg_stat_activity act left join pg_stat_activity blk  \
  on (pg_blocking_pids(act.pid))[1] = blk.pid,get_parsedinfo(act.pid) gpi \
  where act.state in ('active', 'idle in transaction') and act.pid != pg_backend_pid()";
@@ -177,7 +182,8 @@ static const char * const pgsa_query_track_idle=
  else act.wait_event_type end as wait_event_type,case when act.wait_event is null \
  then 'CPU' else act.wait_event end as wait_event, act.state, act.backend_xid, \
  act.backend_xmin, act.query, act.backend_type,(pg_blocking_pids(act.pid))[1], \
- cardinality(pg_blocking_pids(act.pid)),blk.state,gpi.*, act.leader_pid \
+ cardinality(pg_blocking_pids(act.pid)),blk.state,gpi.pid,gpi.queryid, \
+ gpi.queryid,gpi.query,gpi.cmdtype,act.leader_pid \
  from pg_stat_activity act left join pg_stat_activity blk  \
  on (pg_blocking_pids(act.pid))[1] = blk.pid,get_parsedinfo(act.pid) gpi \
  where act.state in ('active', 'idle in transaction') and act.pid != pg_backend_pid()";
@@ -189,7 +195,7 @@ static const char * const pgsa_query_track_idle=
  else act.wait_event_type end as wait_event_type,case when act.wait_event is null \
  then 'CPU' else act.wait_event end as wait_event, act.state, act.backend_xid, \
  act.backend_xmin, act.query, act.backend_type,(pg_blocking_pids(act.pid))[1], \
- cardinality(pg_blocking_pids(act.pid)),blk.state,gpi.pid,act.query_id, \
+ cardinality(pg_blocking_pids(act.pid)),blk.state,gpi.pid,gpi.queryid,act.query_id, \
  gpi.query, gpi.cmdtype, act.leader_pid \
  from pg_stat_activity act left join pg_stat_activity blk  \
  on (pg_blocking_pids(act.pid))[1] = blk.pid,get_parsedinfo(act.pid) gpi \
@@ -204,6 +210,9 @@ static const char * const pg_stat_statements_query=
  temp_blks_written, blk_read_time, blk_write_time from pg_stat_statements(false) \
  where queryid in  (select queryid from pg_active_session_history  \
  where ash_time in (select ash_time from pg_active_session_history  \
+ order by ash_time desc limit 2) \
+ union select nested_queryid from pg_active_session_history \
+ where ash_time in (select ash_time from pg_active_session_history \
  order by ash_time desc limit 2))";
 #elif PG_VERSION_NUM < 170000
 "select userid, dbid, queryid, calls, total_exec_time, rows, shared_blks_hit, \
@@ -214,6 +223,9 @@ static const char * const pg_stat_statements_query=
  from pg_stat_statements(false) \
  where queryid in  (select queryid from pg_active_session_history  \
  where ash_time in (select ash_time from pg_active_session_history  \
+ order by ash_time desc limit 2) \
+ union select nested_queryid from pg_active_session_history \
+ where ash_time in (select ash_time from pg_active_session_history \
  order by ash_time desc limit 2))";
 #else
 "select userid, dbid, queryid, calls, total_exec_time, rows, shared_blks_hit, \
@@ -224,6 +236,9 @@ static const char * const pg_stat_statements_query=
  from pg_stat_statements(false) \
  where queryid in  (select queryid from pg_active_session_history  \
  where ash_time in (select ash_time from pg_active_session_history  \
+ order by ash_time desc limit 2) \
+ union select nested_queryid from pg_active_session_history \
+ where ash_time in (select ash_time from pg_active_session_history \
  order by ash_time desc limit 2))";
 #endif
 
@@ -242,6 +257,7 @@ typedef struct ashEntry
 #endif
 	int client_port;
 	uint64 queryid;
+	uint64 nested_queryid;
 	TimestampTz ash_time;
 	Oid datid;
 	Oid usesysid;
@@ -348,6 +364,7 @@ static void ash_entry_store(TimestampTz ash_time,const int pid,
 							Oid usesysid, TransactionId backend_xid,
 							int blockers, int blockerpid,
 							const char *blocker_state, uint64 queryid,
+							uint64 nested_queryid,
 							const char *gpi_query, const char *cmdtype);
 
 /* prepare store ash */
@@ -369,7 +386,8 @@ static void ash_prepare_store(TimestampTz ash_time,const int pid,
 								const char *backend_type, Oid usesysid,
 								TransactionId backend_xid, int blockers,
 								int blockerpid, const char *blocker_state,
-								uint64 queryid, const char *gpi_query,
+								uint64 queryid, uint64 nested_queryid,
+								const char *gpi_query,
 								const char *cmdtype);
 
 /* Estimate amount of shared memory needed for ash entry */
@@ -811,7 +829,8 @@ ash_entry_store(TimestampTz ash_time, const int pid,
 				const char *backend_type, Oid usesysid,
 				TransactionId backend_xid, int blockers, int blockerpid,
 				const char *blocker_state, uint64 queryid,
-				const char *gpi_query, const char *cmdtype)
+				uint64 nested_queryid, const char *gpi_query,
+				const char *cmdtype)
 {
 	int inserted;
 	inserted=IntEntryArray[0].inserted-1;
@@ -858,6 +877,7 @@ ash_entry_store(TimestampTz ash_time, const int pid,
 	AshEntryArray[inserted].blockers=blockers;
 	AshEntryArray[inserted].blockerpid=blockerpid;
 	AshEntryArray[inserted].queryid=queryid;
+	AshEntryArray[inserted].nested_queryid=nested_queryid;
 }
 
 static void
@@ -876,7 +896,8 @@ ash_prepare_store(TimestampTz ash_time, const int pid,
 					const char *backend_type, Oid usesysid,
 					TransactionId backend_xid, int blockers, int blockerpid,
 					const char *blocker_state, uint64 queryid,
-					const char *gpi_query, const char *cmdtype)
+					uint64 nested_queryid, const char *gpi_query,
+					const char *cmdtype)
 {
 	/* Safety check... */
 	if (!AshEntryArray) { return; }
@@ -891,7 +912,7 @@ ash_prepare_store(TimestampTz ash_time, const int pid,
 					xact_start, query_start, state_change, wait_event_type,
 					wait_event, state, client_hostname, query, backend_type,
 					usesysid, backend_xid, blockers, blockerpid, blocker_state,
-					queryid, gpi_query, cmdtype);
+					queryid, nested_queryid, gpi_query, cmdtype);
 }
 
 void
@@ -1039,6 +1060,7 @@ letswait:
 				TimestampTz query_startvalue;
 				TimestampTz state_changevalue;
 				uint64 queryidvalue;
+				uint64 nested_queryidvalue;
 				char *gpi_queryvalue = NULL;
 				char *cmdtypevalue = NULL;
 
@@ -1125,20 +1147,24 @@ letswait:
 					blockerstatevalue = TextDatumGetCString(data);
 				}
 
-				/* queryid */
+				/* top-level queryid */
 				queryidvalue = DatumGetUInt64(SPI_getbinval(
+					SPI_tuptable->vals[i],SPI_tuptable->tupdesc,26, &isnull));
+
+				/* nested queryid from get_parsedinfo */
+				nested_queryidvalue = DatumGetUInt64(SPI_getbinval(
 					SPI_tuptable->vals[i],SPI_tuptable->tupdesc,25, &isnull));
 
 				/* gpi query */
 				data=SPI_getbinval(SPI_tuptable->vals[i],SPI_tuptable->tupdesc,
-																26, &isnull);
+																		27, &isnull);
 				if (!isnull) {
 					gpi_queryvalue = TextDatumGetCString(data);
 				}
 
 				/* cmdtype */
 				data=SPI_getbinval(SPI_tuptable->vals[i],SPI_tuptable->tupdesc,
-																27, &isnull);
+																		28, &isnull);
 				if (!isnull) {
 					cmdtypevalue = TextDatumGetCString(data);
 				}
@@ -1150,20 +1176,24 @@ letswait:
 					blockerstatevalue = TextDatumGetCString(data);
 				}
 
-				/* queryid */
+				/* top-level queryid */
 				queryidvalue = DatumGetUInt64(SPI_getbinval(
+					SPI_tuptable->vals[i],SPI_tuptable->tupdesc,25, &isnull));
+
+				/* nested queryid from get_parsedinfo */
+				nested_queryidvalue = DatumGetUInt64(SPI_getbinval(
 					SPI_tuptable->vals[i],SPI_tuptable->tupdesc,24, &isnull));
 
 				/* gpi query */
 				data=SPI_getbinval(SPI_tuptable->vals[i],SPI_tuptable->tupdesc,
-																25, &isnull);
+																		26, &isnull);
 				if (!isnull) {
 					gpi_queryvalue = TextDatumGetCString(data);
 				}
 
 				/* cmdtype */
 				data=SPI_getbinval(SPI_tuptable->vals[i],SPI_tuptable->tupdesc,
-																26, &isnull);
+																		27, &isnull);
 				if (!isnull) {
 					cmdtypevalue = TextDatumGetCString(data);
 				}
@@ -1225,7 +1255,7 @@ letswait:
 #if PG_VERSION_NUM >= 130000
 				/* leader pid */
 				leader_pidvalue = DatumGetInt32(SPI_getbinval(
-					SPI_tuptable->vals[i],SPI_tuptable->tupdesc,28, &isnull));
+					SPI_tuptable->vals[i],SPI_tuptable->tupdesc,29, &isnull));
 #endif
 
 				/* prepare to store the entry */
@@ -1250,7 +1280,7 @@ letswait:
 									usesysidvalue, backend_xidvalue,
 									blockersvalue, blockerpidvalue,
 									blockerstatevalue ? blockerstatevalue : "\0",
-									queryidvalue,
+									queryidvalue, nested_queryidvalue,
 									gpi_queryvalue ? gpi_queryvalue : "\0",
 									cmdtypevalue ? cmdtypevalue : "\0");
 			}
@@ -1692,6 +1722,12 @@ pg_active_session_history_internal(FunctionCallInfo fcinfo)
 		{
 			nulls[j++] = true;
 		}
+
+		// nested_queryid - apply privilege check
+		if (show_text && AshEntryArray[i].nested_queryid)
+			values[j++] = Int64GetDatum(AshEntryArray[i].nested_queryid);
+		else
+			nulls[j++] = true;
 
 
 		// backend_type

--- a/src/pgsentinel.c
+++ b/src/pgsentinel.c
@@ -201,7 +201,7 @@ static const char * const pg_stat_statements_query=
 "select userid, dbid, queryid, calls, total_time, rows, shared_blks_hit, \
  shared_blks_read, shared_blks_dirtied, shared_blks_written, local_blks_hit, \
  local_blks_read, local_blks_dirtied, local_blks_written, temp_blks_read, \
- temp_blks_written, blk_read_time, blk_write_time from pg_stat_statements \
+ temp_blks_written, blk_read_time, blk_write_time from pg_stat_statements(false) \
  where queryid in  (select queryid from pg_active_session_history  \
  where ash_time in (select ash_time from pg_active_session_history  \
  order by ash_time desc limit 2))";
@@ -211,7 +211,7 @@ static const char * const pg_stat_statements_query=
  local_blks_read, local_blks_dirtied, local_blks_written, temp_blks_read, \
  temp_blks_written, blk_read_time, blk_write_time, \
  plans, total_plan_time, wal_records, wal_fpi, wal_bytes \
- from pg_stat_statements \
+ from pg_stat_statements(false) \
  where queryid in  (select queryid from pg_active_session_history  \
  where ash_time in (select ash_time from pg_active_session_history  \
  order by ash_time desc limit 2))";
@@ -221,7 +221,7 @@ static const char * const pg_stat_statements_query=
  local_blks_read, local_blks_dirtied, local_blks_written, temp_blks_read, \
  temp_blks_written, shared_blk_read_time, shared_blk_write_time, \
  plans, total_plan_time, wal_records, wal_fpi, wal_bytes \
- from pg_stat_statements \
+ from pg_stat_statements(false) \
  where queryid in  (select queryid from pg_active_session_history  \
  where ash_time in (select ash_time from pg_active_session_history  \
  order by ash_time desc limit 2))";

--- a/src/pgsentinel.c
+++ b/src/pgsentinel.c
@@ -204,7 +204,7 @@ static const char * const pg_stat_statements_query=
  temp_blks_written, blk_read_time, blk_write_time from pg_stat_statements \
  where queryid in  (select queryid from pg_active_session_history  \
  where ash_time in (select ash_time from pg_active_session_history  \
- order by ash_time desc limit 1))";
+ order by ash_time desc limit 2))";
 #elif PG_VERSION_NUM < 170000
 "select userid, dbid, queryid, calls, total_exec_time, rows, shared_blks_hit, \
  shared_blks_read, shared_blks_dirtied, shared_blks_written, local_blks_hit, \
@@ -214,7 +214,7 @@ static const char * const pg_stat_statements_query=
  from pg_stat_statements \
  where queryid in  (select queryid from pg_active_session_history  \
  where ash_time in (select ash_time from pg_active_session_history  \
- order by ash_time desc limit 1))";
+ order by ash_time desc limit 2))";
 #else
 "select userid, dbid, queryid, calls, total_exec_time, rows, shared_blks_hit, \
  shared_blks_read, shared_blks_dirtied, shared_blks_written, local_blks_hit, \
@@ -224,7 +224,7 @@ static const char * const pg_stat_statements_query=
  from pg_stat_statements \
  where queryid in  (select queryid from pg_active_session_history  \
  where ash_time in (select ash_time from pg_active_session_history  \
- order by ash_time desc limit 1))";
+ order by ash_time desc limit 2))";
 #endif
 
 static void pg_active_session_history_internal(FunctionCallInfo fcinfo);
@@ -899,6 +899,7 @@ pgsentinel_main(Datum main_arg)
 {
 	MemoryContext pgsentinel_loop_context;
 	MemoryContext saved_context;
+	bool collect_pgssh_on_idle = false;
 
 	ereport(LOG, (errmsg("starting bgworker pgsentinel")));
 
@@ -932,6 +933,7 @@ pgsentinel_main(Datum main_arg)
 		int rc, ret;
 		uint64 i;
 		bool gotactives;
+		bool collect_pgssh;
 		TimestampTz ash_time;
 		gotactives=false; 
 
@@ -1259,7 +1261,11 @@ letswait:
 		pgstat_report_activity(STATE_IDLE, NULL);
 
 		/* pg_stat_statement_history */
-		if (gotactives && pgssh_enable) 
+		collect_pgssh = gotactives || collect_pgssh_on_idle;
+		/* Remember active sessions so pg_stat_statement_history is collected once on the following idle cycle. */
+		collect_pgssh_on_idle = gotactives;
+
+		if (collect_pgssh && pgssh_enable) 
 		{
 			SetCurrentStatementStartTimestamp();
 			StartTransactionCommand();

--- a/src/pgsentinel.control
+++ b/src/pgsentinel.control
@@ -1,4 +1,4 @@
 comment = 'active session history'
-default_version = '1.4.1'
+default_version = '1.5.0'
 module_pathname = '$libdir/pgsentinel'
 relocatable = true

--- a/src/sql/pgsentinel-test.sql
+++ b/src/sql/pgsentinel-test.sql
@@ -4,6 +4,38 @@ select pg_sleep(3);
 select count(*) > 0 AS has_data from pg_active_session_history where queryid in (select queryid from pg_stat_statements);
 select pg_sleep(3);
 select count(*) > 0 AS has_pgssh_data from pg_stat_statements_history;
+select 'test2' test2, pg_sleep(3);
+select 'test2' test2, pg_sleep(3);
+-- Elicit a few seconds where pgsentinel collection is idle.
+\! sleep 2
+
+-- Exercise pgssh's limit 2 path when the query disappears from ASH while collection is not idle.
+with ash as (
+	select queryid, max(ash_time) as max_ash_time
+	from pg_active_session_history
+	where query like 'select pg_sleep(3)%'
+	group by queryid
+), pgssh as (
+	select queryid, max(ash_time) as max_ash_time
+	from pg_stat_statements_history
+	group by queryid
+)
+select pgssh.max_ash_time > ash.max_ash_time as pgssh_after_ash
+from ash join pgssh using (queryid);
+
+-- Exercise pgssh's collect_pgssh_on_idle path when the query disappears from ASH while collection is idle.
+with ash as (
+	select queryid, max(ash_time) as max_ash_time
+	from pg_active_session_history
+	where query like 'select ''test2'' test2, pg_sleep(3)%'
+	group by queryid
+), pgssh as (
+	select queryid, max(ash_time) as max_ash_time
+	from pg_stat_statements_history
+	group by queryid
+)
+select pgssh.max_ash_time > ash.max_ash_time as pgssh_after_ash
+from ash join pgssh using (queryid);
 
 begin;
 \! sleep 3

--- a/src/sql/pgsentinel-test.sql
+++ b/src/sql/pgsentinel-test.sql
@@ -1,7 +1,39 @@
 CREATE EXTENSION pg_stat_statements;
 CREATE EXTENSION pgsentinel;
+SET pg_stat_statements.track = 'all';
 select pg_sleep(3);
 select count(*) > 0 AS has_data from pg_active_session_history where queryid in (select queryid from pg_stat_statements);
+
+CREATE FUNCTION pgsentinel_nested_queryid_test() RETURNS void AS $$
+BEGIN
+  PERFORM pg_sleep(4);
+END;
+$$ LANGUAGE plpgsql;
+SELECT pgsentinel_nested_queryid_test();
+
+-- Verify ASH records a distinct nested query ID.
+SELECT CASE WHEN current_setting('server_version_num')::integer >= 160000
+       THEN count(*) > 0 ELSE true END AS has_nested_queryid
+FROM pg_active_session_history
+WHERE nested_queryid IS NOT NULL AND nested_queryid <> queryid;
+SELECT pgsentinel_nested_queryid_test();
+
+-- Verify pgssh includes both top-level and nested query IDs.
+SELECT CASE WHEN current_setting('server_version_num')::integer >= 160000
+       THEN count(DISTINCT h.queryid) = 2 ELSE true END
+       AS has_nested_pgssh_queryids
+FROM pg_stat_statements_history AS h
+WHERE h.queryid IN (
+  SELECT queryid
+  FROM pg_active_session_history
+  WHERE top_level_query LIKE 'SELECT pgsentinel_nested_queryid_test()%'
+  UNION
+  SELECT nested_queryid
+  FROM pg_active_session_history
+  WHERE top_level_query LIKE 'SELECT pgsentinel_nested_queryid_test()%'
+);
+DROP FUNCTION pgsentinel_nested_queryid_test();
+
 select pg_sleep(3);
 select count(*) > 0 AS has_pgssh_data from pg_stat_statements_history;
 select 'test2' test2, pg_sleep(3);


### PR DESCRIPTION
add nested queryid as an explicit column in pg_active_session_history and update pgssh data collection to collect data for both top-level and nested queries. this is per discussion in #65. since this adds a new feature to pgsentinel i also bumped the version to `1.5.0` - happy to reorganize into a separate PR if desired.

this PR is intentionally based on top of the branch for #68 and assumes that will be merged first and this will be applied on top of it. (Happy to rebase this if #68 is squashed.)

Closes #73 