### PR TITLE
Update README build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 `pgsentinel` – sampling active session history
 =============================================================
 
-[![Build Status](https://travis-ci.org/pgsentinel/pgsentinel.svg?branch=master)](https://travis-ci.org/pgsentinel/pgsentinel)
+[![Build Status](https://github.com/pgsentinel/pgsentinel/actions/workflows/regression.yml/badge.svg)](https://github.com/pgsentinel/pgsentinel/actions/workflows/regression.yml)
 
 Introduction
 ------------


### PR DESCRIPTION
Current build badge in README points to travis-ci.org and seems to always have a status of unknown. this PR switches the badge to the GH regression tests since we're running them here now.